### PR TITLE
fix ProviderName filter format

### DIFF
--- a/lib/winevent.js
+++ b/lib/winevent.js
@@ -106,21 +106,21 @@ class WinEventReader {
             this.options.providers.forEach((provider, index) => {
                 debug('index: ' + index);
                 if (index === 0 && this.options.providers.length === 1) {
-                    providers += provider;
+                    providers += '\'' + provider + '\'';
                     return;
                 } else if (index === 0 && this.options.providers.length > 1) {
-                    providers += provider + ', ';
+                    providers += '\'' + provider + '\', ';
                     return;
                 } else if (index === this.options.providers.length - 1) {
-                    providers += ' ' + provider
+                    providers += '\'' + provider+ '\''
                     return;
                 }
-                providers += ' ' + provider + ','
+                providers += '\'' + provider + '\', '
             });
 
             // will output json
-            var powershellCmd = 'powershell "Get-WinEvent -FilterHashTable @{ProviderName=\'' 
-            + providers + '\'; StartTime=\'' + this._powershellDate(this.options.startTime) 
+            var powershellCmd = 'powershell "Get-WinEvent -FilterHashTable @{ProviderName=('
+            + providers + '); StartTime=\'' + this._powershellDate(this.options.startTime)
             + '\'; EndTime=\'' + this._powershellDate(this.options.endTime)
             + '\'; }' + ' -MaxEvents ' + this.options.maxEvents + ' | ConvertTo-Json"' ;
             debug(powershellCmd);


### PR DESCRIPTION
The correct format for ProviderName filter should be ProviderName=('provider1', 'provider2'), instead of previous ProviderName='provider1, provider2'. Tested on Windows 10.